### PR TITLE
Add an ability to parse Float viewport size

### DIFF
--- a/src/main/kotlin/imagevector/ComposeMethodCreator.kt
+++ b/src/main/kotlin/imagevector/ComposeMethodCreator.kt
@@ -11,7 +11,7 @@ internal class ComposeMethodCreator(private val indentation: CharSequence) {
         indent().append("defaultWidth = ${set.width}.dp,").appendLine()
         indent().append("defaultHeight = ${set.height}.dp,").appendLine()
         indent().append("viewportWidth = ${set.viewportWidth}f,").appendLine()
-        indent().append("viewportHeight = ${set.viewportWidth}f").appendLine()
+        indent().append("viewportHeight = ${set.viewportHeight}f").appendLine()
         append(")")
     }
 

--- a/src/main/kotlin/models/VectorSet.kt
+++ b/src/main/kotlin/models/VectorSet.kt
@@ -5,8 +5,8 @@ import commands.Command
 internal data class VectorSet(
     val width: Int,
     val height: Int,
-    val viewportWidth: Int,
-    val viewportHeight: Int,
+    val viewportWidth: Float,
+    val viewportHeight: Float,
     val groups: List<Group>,
     val paths: List<Path>
 ) {

--- a/src/main/kotlin/svg/SVGParser.kt
+++ b/src/main/kotlin/svg/SVGParser.kt
@@ -16,7 +16,7 @@ internal class SVGParser(
     private fun SVG.toVectorSet(): VectorSet {
         val width = width.filter { it.isDigit() }.toInt()
         val height = height.filter { it.isDigit() }.toInt()
-        val rect = viewBox?.split(" ")?.map { it.toInt() } ?: listOf(0, 0, width, height)
+        val rect: List<Float> = viewBox?.split(" ")?.map { it.toFloat() } ?: listOf(0, 0, width, height).map { it.toFloat() }
         return VectorSet(
             width = width,
             height = height,

--- a/src/main/kotlin/vectordrawable/VectorDrawable.kt
+++ b/src/main/kotlin/vectordrawable/VectorDrawable.kt
@@ -11,9 +11,9 @@ internal data class VectorDrawable(
     @field:JacksonXmlProperty(localName = "height")
     val heightInDp: String,
     @field:JacksonXmlProperty(localName = "viewportWidth")
-    val viewportWidth: Int,
+    val viewportWidth: Float,
     @field:JacksonXmlProperty(localName = "viewportHeight")
-    val viewportHeight: Int,
+    val viewportHeight: Float,
     @field:JacksonXmlProperty(localName = "tint")
     val tint: String? = null,
     @field:JacksonXmlElementWrapper(useWrapping = false)

--- a/src/test/kotlin/fileparser/SVGFileParserTest.kt
+++ b/src/test/kotlin/fileparser/SVGFileParserTest.kt
@@ -23,8 +23,8 @@ class SVGFileParserTest {
                     name = "search_24",
                     defaultWidth = 24.dp,
                     defaultHeight = 24.dp,
-                    viewportWidth = 24f,
-                    viewportHeight = 24f
+                    viewportWidth = 24.0f,
+                    viewportHeight = 24.0f
                 """.trimIndent()
             )
         }
@@ -41,8 +41,8 @@ class SVGFileParserTest {
                     name = "account_circle_24",
                     defaultWidth = 24.dp,
                     defaultHeight = 24.dp,
-                    viewportWidth = 24f,
-                    viewportHeight = 24f
+                    viewportWidth = 24.0f,
+                    viewportHeight = 24.0f
                 """.trimIndent()
             )
         }
@@ -59,8 +59,8 @@ class SVGFileParserTest {
                     name = "check_circle_48",
                     defaultWidth = 48.dp,
                     defaultHeight = 48.dp,
-                    viewportWidth = 48f,
-                    viewportHeight = 48f
+                    viewportWidth = 48.0f,
+                    viewportHeight = 48.0f
                 """.trimIndent()
             )
         }
@@ -77,8 +77,8 @@ class SVGFileParserTest {
                     name = "delete_48",
                     defaultWidth = 48.dp,
                     defaultHeight = 48.dp,
-                    viewportWidth = 48f,
-                    viewportHeight = 48f
+                    viewportWidth = 48.0f,
+                    viewportHeight = 48.0f
                 """.trimIndent()
             )
         }
@@ -95,8 +95,8 @@ class SVGFileParserTest {
                     name = "done_24",
                     defaultWidth = 24.dp,
                     defaultHeight = 24.dp,
-                    viewportWidth = 24f,
-                    viewportHeight = 24f
+                    viewportWidth = 24.0f,
+                    viewportHeight = 24.0f
                 """.trimIndent()
             )
         }
@@ -113,8 +113,8 @@ class SVGFileParserTest {
                     name = "home_24",
                     defaultWidth = 24.dp,
                     defaultHeight = 24.dp,
-                    viewportWidth = 24f,
-                    viewportHeight = 24f
+                    viewportWidth = 24.0f,
+                    viewportHeight = 24.0f
                 """.trimIndent()
             )
         }
@@ -131,8 +131,8 @@ class SVGFileParserTest {
                     name = "info_24",
                     defaultWidth = 24.dp,
                     defaultHeight = 24.dp,
-                    viewportWidth = 24f,
-                    viewportHeight = 24f
+                    viewportWidth = 24.0f,
+                    viewportHeight = 24.0f
                 """.trimIndent()
             )
         }
@@ -149,8 +149,8 @@ class SVGFileParserTest {
                     name = "settings_24",
                     defaultWidth = 24.dp,
                     defaultHeight = 24.dp,
-                    viewportWidth = 24f,
-                    viewportHeight = 24f
+                    viewportWidth = 24.0f,
+                    viewportHeight = 24.0f
                 ).group(
                     rotate = 0f,
                     pivotX = 0f,
@@ -256,8 +256,8 @@ class SVGFileParserTest {
                     name = "partly_cloudy_night_24",
                     defaultWidth = 48.dp,
                     defaultHeight = 48.dp,
-                    viewportWidth = 48f,
-                    viewportHeight = 48f
+                    viewportWidth = 48.0f,
+                    viewportHeight = 48.0f
                 )
             """.trimIndent()
         )

--- a/src/test/kotlin/fileparser/XMLFileParserTest.kt
+++ b/src/test/kotlin/fileparser/XMLFileParserTest.kt
@@ -22,8 +22,8 @@ internal class XMLFileParserTest {
                     name = "ic_account_circle_24",
                     defaultWidth = 24.dp,
                     defaultHeight = 24.dp,
-                    viewportWidth = 24f,
-                    viewportHeight = 24f
+                    viewportWidth = 24.0f,
+                    viewportHeight = 24.0f
                 """.trimIndent()
             )
         }
@@ -40,8 +40,8 @@ internal class XMLFileParserTest {
                     name = "ic_check_circle_24",
                     defaultWidth = 24.dp,
                     defaultHeight = 24.dp,
-                    viewportWidth = 24f,
-                    viewportHeight = 24f
+                    viewportWidth = 24.0f,
+                    viewportHeight = 24.0f
                 """.trimIndent()
             )
         }
@@ -58,8 +58,8 @@ internal class XMLFileParserTest {
                     name = "ic_delete_24",
                     defaultWidth = 24.dp,
                     defaultHeight = 24.dp,
-                    viewportWidth = 24f,
-                    viewportHeight = 24f
+                    viewportWidth = 24.0f,
+                    viewportHeight = 24.0f
                 """.trimIndent()
             )
         }
@@ -76,8 +76,8 @@ internal class XMLFileParserTest {
                     name = "ic_done_24",
                     defaultWidth = 24.dp,
                     defaultHeight = 24.dp,
-                    viewportWidth = 24f,
-                    viewportHeight = 24f
+                    viewportWidth = 24.0f,
+                    viewportHeight = 24.0f
                 """.trimIndent()
             )
         }
@@ -94,8 +94,8 @@ internal class XMLFileParserTest {
                     name = "ic_home_24",
                     defaultWidth = 24.dp,
                     defaultHeight = 24.dp,
-                    viewportWidth = 24f,
-                    viewportHeight = 24f
+                    viewportWidth = 24.0f,
+                    viewportHeight = 24.0f
                 """.trimIndent()
             )
         }
@@ -112,8 +112,8 @@ internal class XMLFileParserTest {
                     name = "ic_info_24",
                     defaultWidth = 24.dp,
                     defaultHeight = 24.dp,
-                    viewportWidth = 24f,
-                    viewportHeight = 24f
+                    viewportWidth = 24.0f,
+                    viewportHeight = 24.0f
                 """.trimIndent()
             )
         }
@@ -130,8 +130,8 @@ internal class XMLFileParserTest {
                     name = "ic_language_24",
                     defaultWidth = 24.dp,
                     defaultHeight = 24.dp,
-                    viewportWidth = 24f,
-                    viewportHeight = 24f
+                    viewportWidth = 24.0f,
+                    viewportHeight = 24.0f
                 """.trimIndent()
             )
         }
@@ -148,8 +148,8 @@ internal class XMLFileParserTest {
                     name = "ic_search_24",
                     defaultWidth = 24.dp,
                     defaultHeight = 24.dp,
-                    viewportWidth = 24f,
-                    viewportHeight = 24f
+                    viewportWidth = 24.0f,
+                    viewportHeight = 24.0f
                 """.trimIndent()
             )
         }
@@ -166,8 +166,8 @@ internal class XMLFileParserTest {
                     name = "ic_settings_24",
                     defaultWidth = 24.dp,
                     defaultHeight = 24.dp,
-                    viewportWidth = 24f,
-                    viewportHeight = 24f
+                    viewportWidth = 24.0f,
+                    viewportHeight = 24.0f
                 """.trimIndent()
             )
         }

--- a/src/test/kotlin/imagevector/ImageVectorParserTest.kt
+++ b/src/test/kotlin/imagevector/ImageVectorParserTest.kt
@@ -14,8 +14,8 @@ internal class ImageVectorParserTest {
         val set = VectorSet(
             width = 24,
             height = 24,
-            viewportWidth = 48,
-            viewportHeight = 42,
+            viewportWidth = 48f,
+            viewportHeight = 42f,
             paths = listOf(
                 VectorSet.Path(
                     fillType = VectorSet.Path.FillType.NonZero,
@@ -35,8 +35,8 @@ internal class ImageVectorParserTest {
                 name = "ic_icon",
                 defaultWidth = 24.dp,
                 defaultHeight = 24.dp,
-                viewportWidth = 48f,
-                viewportHeight = 42f
+                viewportWidth = 48.0f,
+                viewportHeight = 42.0f
             ).path(
                 fill = SolidColor(Color.Black),
                 fillAlpha = 1f,
@@ -65,8 +65,8 @@ internal class ImageVectorParserTest {
         val set = VectorSet(
             width = 24,
             height = 24,
-            viewportWidth = 48,
-            viewportHeight = 42,
+            viewportWidth = 48f,
+            viewportHeight = 42f,
             paths = listOf(
                 VectorSet.Path(
                     fillType = VectorSet.Path.FillType.EvenOdd,
@@ -86,8 +86,8 @@ internal class ImageVectorParserTest {
                 name = "ic_icon",
                 defaultWidth = 24.dp,
                 defaultHeight = 24.dp,
-                viewportWidth = 48f,
-                viewportHeight = 42f
+                viewportWidth = 48.0f,
+                viewportHeight = 42.0f
             ).path(
                 fill = SolidColor(Color.Black),
                 fillAlpha = 1f,

--- a/src/test/kotlin/imagevector/ImageVectorParserTest.kt
+++ b/src/test/kotlin/imagevector/ImageVectorParserTest.kt
@@ -15,7 +15,7 @@ internal class ImageVectorParserTest {
             width = 24,
             height = 24,
             viewportWidth = 48,
-            viewportHeight = 48,
+            viewportHeight = 42,
             paths = listOf(
                 VectorSet.Path(
                     fillType = VectorSet.Path.FillType.NonZero,
@@ -36,7 +36,7 @@ internal class ImageVectorParserTest {
                 defaultWidth = 24.dp,
                 defaultHeight = 24.dp,
                 viewportWidth = 48f,
-                viewportHeight = 48f
+                viewportHeight = 42f
             ).path(
                 fill = SolidColor(Color.Black),
                 fillAlpha = 1f,
@@ -66,7 +66,7 @@ internal class ImageVectorParserTest {
             width = 24,
             height = 24,
             viewportWidth = 48,
-            viewportHeight = 48,
+            viewportHeight = 42,
             paths = listOf(
                 VectorSet.Path(
                     fillType = VectorSet.Path.FillType.EvenOdd,
@@ -87,7 +87,7 @@ internal class ImageVectorParserTest {
                 defaultWidth = 24.dp,
                 defaultHeight = 24.dp,
                 viewportWidth = 48f,
-                viewportHeight = 48f
+                viewportHeight = 42f
             ).path(
                 fill = SolidColor(Color.Black),
                 fillAlpha = 1f,

--- a/src/test/kotlin/vectordrawable/VectorDrawableParserTest.kt
+++ b/src/test/kotlin/vectordrawable/VectorDrawableParserTest.kt
@@ -35,8 +35,8 @@ internal class VectorDrawableParserTest {
             expected = VectorSet(
                 width = 24,
                 height = 24,
-                viewportWidth = 24,
-                viewportHeight = 24,
+                viewportWidth = 24f,
+                viewportHeight = 24f,
                 paths = listOf(
                     VectorSet.Path(
                         fillType = VectorSet.Path.FillType.NonZero,
@@ -77,8 +77,8 @@ internal class VectorDrawableParserTest {
             expected = VectorSet(
                 width = 24,
                 height = 24,
-                viewportWidth = 24,
-                viewportHeight = 24,
+                viewportWidth = 24f,
+                viewportHeight = 24f,
                 paths = listOf(
                     VectorSet.Path(
                         fillType = VectorSet.Path.FillType.EvenOdd,

--- a/src/test/kotlin/vectordrawable/VectorDrawableSerializerTest.kt
+++ b/src/test/kotlin/vectordrawable/VectorDrawableSerializerTest.kt
@@ -29,8 +29,8 @@ internal class VectorDrawableSerializerTest {
             expected = VectorDrawable(
                 widthInDp = "24dp",
                 heightInDp = "24dp",
-                viewportWidth = 24,
-                viewportHeight = 24,
+                viewportWidth = 24f,
+                viewportHeight = 24f,
                 tint = "?attr/colorControlNormal",
                 path = listOf(
                     VectorDrawable.Path(
@@ -65,8 +65,8 @@ internal class VectorDrawableSerializerTest {
             expected = VectorDrawable(
                 widthInDp = "24dp",
                 heightInDp = "24dp",
-                viewportWidth = 24,
-                viewportHeight = 24,
+                viewportWidth = 24f,
+                viewportHeight = 24f,
                 tint = "?attr/colorControlNormal",
                 path = listOf(
                     VectorDrawable.Path(
@@ -126,8 +126,8 @@ internal class VectorDrawableSerializerTest {
             expected = VectorDrawable(
                 widthInDp = "24dp",
                 heightInDp = "24dp",
-                viewportWidth = 24,
-                viewportHeight = 24,
+                viewportWidth = 24f,
+                viewportHeight = 24f,
                 tint = null,
                 path = emptyList(),
                 group = listOf(
@@ -181,8 +181,8 @@ internal class VectorDrawableSerializerTest {
             expected = VectorDrawable(
                 widthInDp = "24dp",
                 heightInDp = "24dp",
-                viewportWidth = 24,
-                viewportHeight = 24,
+                viewportWidth = 24f,
+                viewportHeight = 24f,
                 tint = null,
                 path = emptyList(),
                 group = listOf(

--- a/src/test/kotlin/vectordrawable/VectorDrawableXmlParserTest.kt
+++ b/src/test/kotlin/vectordrawable/VectorDrawableXmlParserTest.kt
@@ -23,8 +23,8 @@ class VectorDrawableXmlParserTest {
             expected = VectorDrawable(
                 widthInDp = "24dp",
                 heightInDp = "24dp",
-                viewportWidth = 24,
-                viewportHeight = 24,
+                viewportWidth = 24f,
+                viewportHeight = 24f,
                 tint = "?attr/colorControlNormal",
                 path = listOf(
                     VectorDrawable.Path(
@@ -57,8 +57,8 @@ class VectorDrawableXmlParserTest {
             expected = VectorDrawable(
                 widthInDp = "24dp",
                 heightInDp = "24dp",
-                viewportWidth = 24,
-                viewportHeight = 24,
+                viewportWidth = 24f,
+                viewportHeight = 24f,
                 tint = "?attr/colorControlNormal",
                 path = listOf(
                     VectorDrawable.Path(


### PR DESCRIPTION
Two commits.
The first fixes mistype (and covers it by changed test).

The second adds an ability to parse Float viewport width and height (was needed in my case).

This is also not breaking in case of integer viewport sizes in xml (this is covered by parser unit-tests).